### PR TITLE
Anchoring update

### DIFF
--- a/include/anchor.hpp
+++ b/include/anchor.hpp
@@ -9,20 +9,14 @@
         {
             Nz::Vector2f min, max;
 
-            anchor() = default;
-            anchor(Nz::Vector2f const & normMin, Nz::Vector2f const & normMax)
-                : min(normMin)
-                , max(normMax) {
-            }
+            using align = Nz::Vector2f;
 
-            using align_t = Nz::Vector2f;
+            static align begin() { return { 0.f, 0.f }; }
+            static align end() { return { 1.f, 1.f }; }
+            static align center() { return { 0.5f, 0.5f }; }
+            static align stretch() { return { 0.f, 1.f }; }
 
-            static align_t begin() { return { 0.f, 0.f }; }
-            static align_t end() { return { 1.f, 1.f }; }
-            static align_t center() { return { 0.5f, 0.5f }; }
-            static align_t stretch() { return { 0.f, 1.f }; }
-
-            static anchor ease(align_t const & horizontal = begin(), align_t const & vertical = begin()) {
+            static anchor ease(align const & horizontal = begin(), align const & vertical = begin()) {
                 return { { horizontal.x, vertical.x }, { horizontal.y, vertical.y } };
             }
         };

--- a/include/base_interface.hpp
+++ b/include/base_interface.hpp
@@ -25,14 +25,12 @@
 
                 virtual void scissor(Nz::Recti const &) = 0;
 
-                void anchor(ex::anchor const & value) {
-                    anchor_ = value;
-                }
-                ex::anchor anchor() const {
-                    return anchor_;
-                }
+                void anchor(base_interface const &, ex::anchor const &);
+                ex::anchor anchor() const;
         };
 
     }
+
+    #include "base_interface.inl"
 
 #endif /* HPP_BASE_INTERFACE_INCLUDED */

--- a/include/base_interface.hpp
+++ b/include/base_interface.hpp
@@ -25,6 +25,7 @@
 
                 virtual void scissor(Nz::Recti const &) = 0;
 
+                void anchor(Nz::Vector3f const &, Nz::Vector2f const &, ex::anchor const &);
                 void anchor(base_interface const &, ex::anchor const &);
                 ex::anchor anchor() const;
         };

--- a/include/base_interface.inl
+++ b/include/base_interface.inl
@@ -1,0 +1,18 @@
+namespace ex {
+
+    void base_interface::anchor(base_interface const & element, ex::anchor const & value) {
+        anchor_ = value;
+        Nz::Vector2f elmsize{ element.size() };
+        Nz::Vector2f siz{ size() };
+        SetInitialPosition(elmsize * anchor_.min + Nz::Vector2f{ element.GetPosition() });
+        size({
+            (anchor_.max.x != anchor_.min.x) ? elmsize.x * (anchor_.max.x - anchor_.min.x) : siz.x
+            , (anchor_.max.y != anchor_.min.y) ? elmsize.y * (anchor_.max.y - anchor_.min.y) : siz.y
+        });
+    }
+
+    ex::anchor base_interface::anchor() const {
+        return anchor_;
+    }
+
+}

--- a/include/base_interface.inl
+++ b/include/base_interface.inl
@@ -1,14 +1,18 @@
 namespace ex {
 
     void base_interface::anchor(base_interface const & element, ex::anchor const & value) {
+    void base_interface::anchor(Nz::Vector3f const & position, Nz::Vector2f const & size, ex::anchor const & value) {
         anchor_ = value;
-        Nz::Vector2f elmsize{ element.size() };
-        Nz::Vector2f siz{ size() };
-        SetInitialPosition(elmsize * anchor_.min + Nz::Vector2f{ element.GetPosition() });
-        size({
-            (anchor_.max.x != anchor_.min.x) ? elmsize.x * (anchor_.max.x - anchor_.min.x) : siz.x
-            , (anchor_.max.y != anchor_.min.y) ? elmsize.y * (anchor_.max.y - anchor_.min.y) : siz.y
+        Nz::Vector2f siz{ this->size() };
+        SetInitialPosition(size * anchor_.min + Nz::Vector2f{ position });
+        this->size({
+            (anchor_.max.x != anchor_.min.x) ? size.x * (anchor_.max.x - anchor_.min.x) : siz.x
+            , (anchor_.max.y != anchor_.min.y) ? size.y * (anchor_.max.y - anchor_.min.y) : siz.y
         });
+    }
+
+    void base_interface::anchor(base_interface const & element, ex::anchor const & value) {
+        anchor(element.GetPosition(), element.size(), value);
     }
 
     ex::anchor base_interface::anchor() const {

--- a/include/base_interface.inl
+++ b/include/base_interface.inl
@@ -1,6 +1,5 @@
 namespace ex {
 
-    void base_interface::anchor(base_interface const & element, ex::anchor const & value) {
     void base_interface::anchor(Nz::Vector3f const & position, Nz::Vector2f const & size, ex::anchor const & value) {
         anchor_ = value;
         Nz::Vector2f siz{ this->size() };

--- a/include/container.inl
+++ b/include/container.inl
@@ -29,13 +29,7 @@ namespace ex {
             if (!*element) {
                 continue;
             }
-            ex::anchor anch { element->anchor() };
-            Nz::Vector2f elmsize { element->size() };
-            element->SetInitialPosition(size_ * anch.min);
-            element->size({
-                (anch.max.x != anch.min.x) ? size_.x * (anch.max.x - anch.min.x) : elmsize.x
-                , (anch.max.y != anch.min.y) ? size_.y * (anch.max.y - anch.min.y) : elmsize.y
-            });
+            element->anchor(*this, element->anchor());
         }
     }
 


### PR DESCRIPTION
* interface's `anchor` method rework : position and size are now directly applied
* Renamed anchor alignement type from `align_t` to `align`
* container's `collocate` method now calls each of its element `anchor` method with container and element's current anchor as parameters.
* Added `base_interface.inl` file and moved implementations into it.