### PR TITLE
Sizing update

### DIFF
--- a/include/anchor.hpp
+++ b/include/anchor.hpp
@@ -9,20 +9,14 @@
         {
             Nz::Vector2f min, max;
 
-            anchor() = default;
-            anchor(Nz::Vector2f const & normMin, Nz::Vector2f const & normMax)
-                : min(normMin)
-                , max(normMax) {
-            }
+            using align = Nz::Vector2f;
 
-            using align_t = Nz::Vector2f;
+            static align begin() { return { 0.f, 0.f }; }
+            static align end() { return { 1.f, 1.f }; }
+            static align center() { return { 0.5f, 0.5f }; }
+            static align stretch() { return { 0.f, 1.f }; }
 
-            static align_t begin() { return { 0.f, 0.f }; }
-            static align_t end() { return { 1.f, 1.f }; }
-            static align_t center() { return { 0.5f, 0.5f }; }
-            static align_t stretch() { return { 0.f, 1.f }; }
-
-            static anchor ease(align_t const & horizontal = begin(), align_t const & vertical = begin()) {
+            static anchor ease(align const & horizontal = begin(), align const & vertical = begin()) {
                 return { { horizontal.x, vertical.x }, { horizontal.y, vertical.y } };
             }
         };

--- a/include/base_interface.hpp
+++ b/include/base_interface.hpp
@@ -2,32 +2,48 @@
 #define HPP_BASE_INTERFACE_INCLUDED
 
     #include <Nazara/Utility/Node.hpp>
-    #include <Nazara/Core/HandledObject.hpp>
 
     #include <anchor.hpp>
     #include <object.hpp>
 
     namespace ex {
 
+        struct padding
+        {
+            float left, top, right, bottom;
+
+            static padding none() {
+                return { 0.f, 0.f, 0.f, 0.f };
+            };
+        };
+
         class base_interface
             : public Nz::Node
             , public object<base_interface>
         {
             ex::anchor anchor_;
+            ex::padding padding_;
+            Nz::Recti scissor_;
+            Nz::Signal<Nz::Node const *>::ConnectionGuard nodeinvalidated_;
 
             public:
+                base_interface();
                 virtual ~base_interface() = default;
 
                 virtual Nz::Vector2f size() const = 0;
-                virtual void size(Nz::Vector2f const & value) = 0;
+                virtual void size(Nz::Vector2f const &) = 0;
 
                 virtual void show(bool value) = 0;
 
-                virtual void scissor(Nz::Recti const &) = 0;
+                virtual void scissor(Nz::Recti const &);
+                Nz::Recti scissor() const;
 
                 void anchor(Nz::Vector3f const &, Nz::Vector2f const &, ex::anchor const &);
                 void anchor(base_interface const &, ex::anchor const &);
                 ex::anchor anchor() const;
+
+                void padding(ex::padding const &);
+                ex::padding padding() const;
         };
 
     }

--- a/include/base_interface.hpp
+++ b/include/base_interface.hpp
@@ -25,14 +25,12 @@
 
                 virtual void scissor(Nz::Recti const &) = 0;
 
-                void anchor(ex::anchor const & value) {
-                    anchor_ = value;
-                }
-                ex::anchor anchor() const {
-                    return anchor_;
-                }
+                void anchor(base_interface const &, ex::anchor const &);
+                ex::anchor anchor() const;
         };
 
     }
+
+    #include "base_interface.inl"
 
 #endif /* HPP_BASE_INTERFACE_INCLUDED */

--- a/include/base_interface.hpp
+++ b/include/base_interface.hpp
@@ -25,6 +25,7 @@
 
                 virtual void scissor(Nz::Recti const &) = 0;
 
+                void anchor(Nz::Vector3f const &, Nz::Vector2f const &, ex::anchor const &);
                 void anchor(base_interface const &, ex::anchor const &);
                 ex::anchor anchor() const;
         };

--- a/include/base_interface.inl
+++ b/include/base_interface.inl
@@ -1,0 +1,18 @@
+namespace ex {
+
+    void base_interface::anchor(base_interface const & element, ex::anchor const & value) {
+        anchor_ = value;
+        Nz::Vector2f elmsize{ element.size() };
+        Nz::Vector2f siz{ size() };
+        SetInitialPosition(elmsize * anchor_.min + Nz::Vector2f{ element.GetPosition() });
+        size({
+            (anchor_.max.x != anchor_.min.x) ? elmsize.x * (anchor_.max.x - anchor_.min.x) : siz.x
+            , (anchor_.max.y != anchor_.min.y) ? elmsize.y * (anchor_.max.y - anchor_.min.y) : siz.y
+        });
+    }
+
+    ex::anchor base_interface::anchor() const {
+        return anchor_;
+    }
+
+}

--- a/include/base_interface.inl
+++ b/include/base_interface.inl
@@ -1,14 +1,18 @@
 namespace ex {
 
     void base_interface::anchor(base_interface const & element, ex::anchor const & value) {
+    void base_interface::anchor(Nz::Vector3f const & position, Nz::Vector2f const & size, ex::anchor const & value) {
         anchor_ = value;
-        Nz::Vector2f elmsize{ element.size() };
-        Nz::Vector2f siz{ size() };
-        SetInitialPosition(elmsize * anchor_.min + Nz::Vector2f{ element.GetPosition() });
-        size({
-            (anchor_.max.x != anchor_.min.x) ? elmsize.x * (anchor_.max.x - anchor_.min.x) : siz.x
-            , (anchor_.max.y != anchor_.min.y) ? elmsize.y * (anchor_.max.y - anchor_.min.y) : siz.y
+        Nz::Vector2f siz{ this->size() };
+        SetInitialPosition(size * anchor_.min + Nz::Vector2f{ position });
+        this->size({
+            (anchor_.max.x != anchor_.min.x) ? size.x * (anchor_.max.x - anchor_.min.x) : siz.x
+            , (anchor_.max.y != anchor_.min.y) ? size.y * (anchor_.max.y - anchor_.min.y) : siz.y
         });
+    }
+
+    void base_interface::anchor(base_interface const & element, ex::anchor const & value) {
+        anchor(element.GetPosition(), element.size(), value);
     }
 
     ex::anchor base_interface::anchor() const {

--- a/include/base_interface.inl
+++ b/include/base_interface.inl
@@ -1,5 +1,14 @@
 namespace ex {
 
+    base_interface::base_interface() {
+        nodeinvalidated_.Connect(OnNodeInvalidation, [this](Nz::Node const *) {
+            Nz::Vector2i pos{ Nz::Vector2f{ GetPosition() } };
+            Nz::Recti current{ scissor() };
+            Nz::Recti rect{ pos.x, pos.y, current.width, current.height };
+            scissor(rect);
+        });
+    }
+
     void base_interface::anchor(Nz::Vector3f const & position, Nz::Vector2f const & size, ex::anchor const & value) {
         anchor_ = value;
         Nz::Vector2f siz{ this->size() };
@@ -18,4 +27,21 @@ namespace ex {
         return anchor_;
     }
 
+    void base_interface::padding(ex::padding const & value) {
+        Nz::Vector2f siz{ size() };
+        padding_ = value;
+        size(siz);
+    }
+
+    ex::padding base_interface::padding() const {
+        return padding_;
+    }
+
+    void base_interface::scissor(Nz::Recti const & value) {
+        scissor_ = value;
+    }
+
+    Nz::Recti base_interface::scissor() const {
+        return scissor_;
+    }
 }

--- a/include/base_interface.inl
+++ b/include/base_interface.inl
@@ -1,6 +1,5 @@
 namespace ex {
 
-    void base_interface::anchor(base_interface const & element, ex::anchor const & value) {
     void base_interface::anchor(Nz::Vector3f const & position, Nz::Vector2f const & size, ex::anchor const & value) {
         anchor_ = value;
         Nz::Vector2f siz{ this->size() };

--- a/include/container.hpp
+++ b/include/container.hpp
@@ -14,7 +14,7 @@
             using owner_type = owner<base_interface>;
 
             std::list<owner_type> elements_;
-            Nz::Vector2f size_;
+            Nz::Vector2f contentsize_;
 
             public:
                 container() = default;

--- a/include/container.inl
+++ b/include/container.inl
@@ -29,13 +29,7 @@ namespace ex {
             if (!*element) {
                 continue;
             }
-            ex::anchor anch { element->anchor() };
-            Nz::Vector2f elmsize { element->size() };
-            element->SetInitialPosition(size_ * anch.min);
-            element->size({
-                (anch.max.x != anch.min.x) ? size_.x * (anch.max.x - anch.min.x) : elmsize.x
-                , (anch.max.y != anch.min.y) ? size_.y * (anch.max.y - anch.min.y) : elmsize.y
-            });
+            element->anchor(*this, element->anchor());
         }
     }
 

--- a/include/container.inl
+++ b/include/container.inl
@@ -25,21 +25,26 @@ namespace ex {
 
     void container::collocate() const
     {
+        ex::padding pad{ padding() };
+        Nz::Vector3f pos{ GetPosition() + Nz::Vector3f{ pad.left, pad.top, 0.f } };
+
         for (auto & element : elements_) {
             if (!*element) {
                 continue;
             }
-            element->anchor(*this, element->anchor());
+            element->anchor(pos, contentsize_, element->anchor());
         }
     }
 
     void container::size(Nz::Vector2f const & value) {
-        size_ = value;
+        ex::padding pad{ padding() };
+        contentsize_ = value - Nz::Vector2f{ pad.left + pad.right, pad.top + pad.bottom };
         collocate();
     }
 
     Nz::Vector2f container::size() const {
-        return size_;
+        ex::padding pad{ padding() };
+        return contentsize_ + Nz::Vector2f{ pad.left + pad.right, pad.top + pad.bottom };
     }
 
     std::size_t container::count() const {
@@ -68,15 +73,31 @@ namespace ex {
     }
 
     void container::scissor(bool value) {
-        Nz::Vector2i pos{ Nz::Vector2f{ GetPosition() } };
-        Nz::Vector2i siz{ size() };
-        Nz::Recti rect{ (value) ? Nz::Recti{ pos.x, pos.y, siz.x, siz.y } : Nz::Recti{ -1, -1 } };
+        ex::padding pad{ padding() };
+        Nz::Vector2i pos{ Nz::Vector2f{ GetPosition() } + Nz::Vector2f{ pad.left, pad.top } };
+        Nz::Recti rect{ (value) ? Nz::Recti{ pos.x, pos.y, static_cast<int>(contentsize_.x), static_cast<int>(contentsize_.y) } : Nz::Recti{ -1, -1 } };
         scissor(rect);
     }
 
     void container::scissor(Nz::Recti const & rect) {
+        base_interface::scissor(rect);
+        if (rect.width >= 0 && rect.height >= 0) {
+            // No constraint applied to elements
+            return;
+        }
         for (auto & elm : elements_) {
-            elm->scissor(rect);
+            Nz::Recti elmscis{ elm->scissor() };
+            if (elmscis.width >= 0 && elmscis.height >= 0) {
+                elmscis.x = std::max(elmscis.x, rect.x);
+                elmscis.y = std::max(elmscis.y, rect.y);
+                elmscis.width = std::min(elmscis.width, rect.width);
+                elmscis.height = std::min(elmscis.height, rect.height);
+            }
+            else {
+                // Element has no constraint but we still apply container's one
+                elmscis = rect;
+            }
+            elm->scissor(elmscis);
         }
     }
 

--- a/include/interface.inl
+++ b/include/interface.inl
@@ -20,16 +20,23 @@ namespace ex {
     template <typename Gfx>
     void interface<Gfx>::data(typename Gfx::value_type const & value) {
         Gfx::apply(gfx_, value);
+        size(size());
     }
 
     template <typename Gfx>
     Nz::Vector2f interface<Gfx>::size() const {
-        return Gfx::size(gfx_);
+        ex::padding pad{ padding() };
+        return Gfx::size(gfx_) + Nz::Vector2f{ pad.left + pad.right, pad.top + pad.bottom };
     }
 
     template <typename Gfx>
     void interface<Gfx>::size(Nz::Vector2f const & value) {
-        Gfx::size(gfx_, value);
+        ex::padding pad{ padding() };
+        Nz::Vector2f contentsize{ value.x - pad.left - pad.right, value.y - pad.top - pad.bottom };
+        Gfx::size(gfx_, contentsize);
+        entity_->GetComponent<Ndk::NodeComponent>().SetPosition(Nz::Vector2f{ pad.left, pad.top });
+        Nz::Vector2i pos{ Nz::Vector2f{ GetPosition() } + Nz::Vector2f{ pad.left, pad.top } };
+        scissor({ pos.x, pos.y, static_cast<int>(contentsize.x), static_cast<int>(contentsize.y) });
     }
 
     template <typename Gfx>
@@ -39,6 +46,7 @@ namespace ex {
 
     template <typename Gfx>
     void interface<Gfx>::scissor(Nz::Recti const & rect) {
+        base_interface::scissor(rect);
         entity_->GetComponent<Ndk::GraphicsComponent>().SetScissorRect(rect);
     }
 


### PR DESCRIPTION
Internal rework of element's sizing
* Reworked `scissor` methods, as elements now know their scissoring
* Container now knows its content size instead of its actual size
* Added element's padding
* Element's node invalidation now invokes element's scissoring, as node movement should update element's scissoring position.

As a matter of fact, elements that are part of a container are anchored to it from container's position and size, **including padding**.
So for instance an horizontal anchoring of [0,0] (i.e. begin) will be computed from container's content position and content size.

Same for scissoring container's elements.